### PR TITLE
feat: SPY endpoints for Bryan strategy

### DIFF
--- a/src/main/kotlin/sg/com/quantai/etl/controllers/StockController.kt
+++ b/src/main/kotlin/sg/com/quantai/etl/controllers/StockController.kt
@@ -92,4 +92,39 @@ class StockController(
             ResponseEntity.internalServerError().body("Error during stock data transformation: ${e.message}")
         }
     }
+
+    @GetMapping("/snp500/daily")
+    fun getSP500DailyPrices(
+        @RequestParam(defaultValue = "30") days: Int
+    ): ResponseEntity<Map<String, Any>> {
+        return try {
+            val effectiveDays = days.coerceIn(1, 365)  // Limit between 1 and 365 days
+            val data = stockService.fetchSP500DailyPrices(effectiveDays)
+            
+            if (data.isEmpty()) {
+                ResponseEntity.ok(mapOf(
+                    "status" to "success",
+                    "message" to "No S&P 500 data available",
+                    "symbol" to "SPY",
+                    "days" to effectiveDays,
+                    "data" to emptyList<Map<String, Any>>()
+                ))
+            } else {
+                ResponseEntity.ok(mapOf(
+                    "status" to "success",
+                    "symbol" to "SPY",
+                    "description" to "S&P 500 ETF (SPDR)",
+                    "interval" to "1day",
+                    "days" to effectiveDays,
+                    "count" to data.size,
+                    "data" to data
+                ))
+            }
+        } catch (e: Exception) {
+            ResponseEntity.internalServerError().body(mapOf(
+                "status" to "error",
+                "message" to "Error fetching S&P 500 data: ${e.message}"
+            ))
+        }
+    }
 }

--- a/src/main/kotlin/sg/com/quantai/etl/controllers/StockController.kt
+++ b/src/main/kotlin/sg/com/quantai/etl/controllers/StockController.kt
@@ -98,28 +98,36 @@ class StockController(
         @RequestParam(defaultValue = "30") days: Int
     ): ResponseEntity<Map<String, Any>> {
         return try {
-            val effectiveDays = days.coerceIn(1, 365)  // Limit between 1 and 365 days
+            // Validate and coerce days parameter
+            val effectiveDays = days.coerceIn(1, 365)
+            val warning: String? = when {
+                days < 1 -> "Parameter 'days' must be at least 1. Adjusted from $days to $effectiveDays."
+                days > 365 -> "Parameter 'days' cannot exceed 365. Adjusted from $days to $effectiveDays."
+                else -> null
+            }
+            
             val data = stockService.fetchSP500DailyPrices(effectiveDays)
             
-            if (data.isEmpty()) {
-                ResponseEntity.ok(mapOf(
-                    "status" to "success",
-                    "message" to "No S&P 500 data available",
-                    "symbol" to "SPY",
-                    "days" to effectiveDays,
-                    "data" to emptyList<Map<String, Any>>()
-                ))
-            } else {
-                ResponseEntity.ok(mapOf(
-                    "status" to "success",
-                    "symbol" to "SPY",
-                    "description" to "S&P 500 ETF (SPDR)",
-                    "interval" to "1day",
-                    "days" to effectiveDays,
-                    "count" to data.size,
-                    "data" to data
-                ))
+            val response = mutableMapOf<String, Any>(
+                "status" to "success",
+                "symbol" to "SPY",
+                "description" to "S&P 500 ETF (SPDR)",
+                "interval" to "1day",
+                "requestedDays" to days,
+                "days" to effectiveDays,
+                "count" to data.size,
+                "data" to data
+            )
+            
+            if (warning != null) {
+                response["warning"] = warning
             }
+            
+            if (data.isEmpty()) {
+                response["message"] = "No S&P 500 data available"
+            }
+            
+            ResponseEntity.ok(response.toMap())
         } catch (e: Exception) {
             ResponseEntity.internalServerError().body(mapOf(
                 "status" to "error",


### PR DESCRIPTION
I believe it will make integration easier if I create a “convenience endpoint” just for SPY, because the existing endpoints require triggering the whole ETL pipeline and having to query the data warehouse afterward.

This will make POC faster.

# 30 days (default)
curl "http://localhost:10070/stock/snp500/daily"

# Custom number of days (1-365)
curl "http://localhost:10070/stock/snp500/daily?days=30"
curl "http://localhost:10070/stock/snp500/daily?days=100"
curl "http://localhost:10070/stock/snp500/daily?days=365"