### PR TITLE
feat: real data for home page (slow due to rate limits of free api key)

### DIFF
--- a/src/main/kotlin/sg/com/quantai/etl/controllers/CryptoController.kt
+++ b/src/main/kotlin/sg/com/quantai/etl/controllers/CryptoController.kt
@@ -108,4 +108,35 @@ class CryptoController(
             "close" to price
         ))
     }
+
+    /**
+     * Fetch historical price data for a cryptocurrency (for chart display)
+     * Example Usage:
+     * GET /crypto/price-history?symbol=BTC&currency=USD&days=30
+     */
+    @GetMapping("/price-history")
+    fun getPriceHistory(
+        @RequestParam symbol: String,
+        @RequestParam(defaultValue = "USD") currency: String,
+        @RequestParam(defaultValue = "30") days: Int
+    ): ResponseEntity<Map<String, Any>> {
+        return try {
+            val effectiveDays = days.coerceIn(1, 365)
+            val data = cryptoService.fetchPriceHistory(symbol, currency, effectiveDays)
+            
+            ResponseEntity.ok(mapOf(
+                "status" to "success",
+                "symbol" to symbol,
+                "currency" to currency,
+                "days" to effectiveDays,
+                "count" to data.size,
+                "data" to data
+            ))
+        } catch (e: Exception) {
+            ResponseEntity.status(500).body(mapOf(
+                "status" to "error",
+                "message" to "Error fetching price history: ${e.message}"
+            ))
+        }
+    }
 }

--- a/src/main/kotlin/sg/com/quantai/etl/controllers/ForexController.kt
+++ b/src/main/kotlin/sg/com/quantai/etl/controllers/ForexController.kt
@@ -61,4 +61,34 @@ class ForexController(
             ResponseEntity.internalServerError().body("Error during forex data transformation: ${e.message}")
         }
     }
+
+    /**
+     * Fetch historical price data for a forex pair (for chart display)
+     * Example Usage:
+     * GET /forex/price-history?currencyPair=EUR/USD&days=30
+     */
+    @GetMapping("/price-history")
+    fun getPriceHistory(
+        @RequestParam currencyPair: String,
+        @RequestParam(defaultValue = "30") days: Int
+    ): ResponseEntity<Map<String, Any>> {
+        return try {
+            val effectiveDays = days.coerceIn(1, 365)
+            val data = forexService.fetchPriceHistory(currencyPair, effectiveDays)
+            
+            ResponseEntity.ok(mapOf(
+                "status" to "success",
+                "currencyPair" to currencyPair,
+                "interval" to "1day",
+                "days" to effectiveDays,
+                "count" to data.size,
+                "data" to data
+            ))
+        } catch (e: Exception) {
+            ResponseEntity.internalServerError().body(mapOf(
+                "status" to "error",
+                "message" to "Error fetching price history: ${e.message}"
+            ))
+        }
+    }
 }

--- a/src/main/kotlin/sg/com/quantai/etl/controllers/StockController.kt
+++ b/src/main/kotlin/sg/com/quantai/etl/controllers/StockController.kt
@@ -135,4 +135,34 @@ class StockController(
             ))
         }
     }
+
+    /**
+     * Fetch historical price data for a stock (for chart display)
+     * Example Usage:
+     * GET /stock/price-history?symbol=AAPL&days=30
+     */
+    @GetMapping("/price-history")
+    fun getPriceHistory(
+        @RequestParam symbol: String,
+        @RequestParam(defaultValue = "30") days: Int
+    ): ResponseEntity<Map<String, Any>> {
+        return try {
+            val effectiveDays = days.coerceIn(1, 365)
+            val data = stockService.fetchPriceHistory(symbol, effectiveDays)
+            
+            ResponseEntity.ok(mapOf(
+                "status" to "success",
+                "symbol" to symbol,
+                "interval" to "1day",
+                "days" to effectiveDays,
+                "count" to data.size,
+                "data" to data
+            ))
+        } catch (e: Exception) {
+            ResponseEntity.internalServerError().body(mapOf(
+                "status" to "error",
+                "message" to "Error fetching price history: ${e.message}"
+            ))
+        }
+    }
 }

--- a/src/main/kotlin/sg/com/quantai/etl/services/StockService.kt
+++ b/src/main/kotlin/sg/com/quantai/etl/services/StockService.kt
@@ -405,4 +405,62 @@ class StockService(
         }
     }
 
+    /**
+     * Fetch historical price data for a stock (for chart display).
+     * Returns a list of price data points for the specified number of days.
+     */
+    fun fetchPriceHistory(symbol: String, days: Int): List<Map<String, Any>> {
+        val interval = "1day"
+        
+        try {
+            logger.info("Fetching price history for stock $symbol for $days days")
+            
+            val response = webClient
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder
+                        .path("/time_series")
+                        .queryParam("symbol", symbol)
+                        .queryParam("interval", interval)
+                        .queryParam("outputsize", days)
+                        .queryParam("apikey", apiKey)
+                        .build()
+                }
+                .retrieve()
+                .bodyToMono(String::class.java)
+                .block()
+
+            val jsonResponse = objectMapper.readTree(response)
+            
+            if (jsonResponse == null || !jsonResponse.has("values") || !jsonResponse["values"].isArray) {
+                logger.warn("No price history data returned for $symbol")
+                return emptyList()
+            }
+
+            val priceData = mutableListOf<Map<String, Any>>()
+            
+            jsonResponse["values"].forEach { node ->
+                try {
+                    priceData.add(mapOf(
+                        "date" to node["datetime"].asText(),
+                        "open" to node["open"].asDouble(),
+                        "high" to node["high"].asDouble(),
+                        "low" to node["low"].asDouble(),
+                        "close" to node["close"].asDouble(),
+                        "volume" to node["volume"].asLong()
+                    ))
+                } catch (e: Exception) {
+                    logger.error("Error parsing price history data point for $symbol: ${e.message}")
+                }
+            }
+
+            logger.info("Successfully fetched ${priceData.size} price history records for $symbol")
+            return priceData
+            
+        } catch (e: Exception) {
+            logger.error("Error fetching price history for $symbol: ${e.message}")
+            throw e
+        }
+    }
+
 }


### PR DESCRIPTION
Home page now fetches real data, twelve data api for stock/forex and cryptocompare for crypto

Loading is a bit slow due to free tier rate limits by twelve data, but seems to be under 10s as discussed.