### PR TITLE
Quantntu 77

### DIFF
--- a/src/main/kotlin/sg/com/quantai/etl/services/DataWarehouseInitializer.kt
+++ b/src/main/kotlin/sg/com/quantai/etl/services/DataWarehouseInitializer.kt
@@ -434,24 +434,24 @@ class DataWarehouseInitializer(val jdbcTemplate: JdbcTemplate) {
                 CREATE OR REPLACE VIEW ohlc_1hour_aggregate AS
                 SELECT 
                     ds.symbol_id,
-                    mv.trading_day as bucket,
+                    mv.trading_hour as bucket,
                     COALESCE(mv.total_volume, 0) as total_volume,
                     COALESCE(mv.total_volume / NULLIF(mv.record_count, 0), 0) as avg_volume,
                     COALESCE(mv.total_volume, 0) as max_volume,
                     0::numeric as min_volume,
-                    COALESCE(mv.day_open, 0) as first_open,
-                    COALESCE(mv.day_close, 0) as last_close,
-                    COALESCE(mv.day_high, 0) as max_high,
-                    COALESCE(mv.day_low, 0) as min_low,
+                    COALESCE(mv.hour_open, 0) as first_open,
+                    COALESCE(mv.hour_close, 0) as last_close,
+                    COALESCE(mv.hour_high, 0) as max_high,
+                    COALESCE(mv.hour_low, 0) as min_low,
                     COALESCE(mv.avg_close_price, 0) as avg_close,
                     COALESCE(
                         CASE 
-                            WHEN mv.day_low > 0 THEN (mv.day_high - mv.day_low) / mv.day_low * 100 
+                            WHEN mv.hour_low > 0 THEN (mv.hour_high - mv.hour_low) / mv.hour_low * 100 
                             ELSE 0 
                         END, 0
                     ) as volatility,
                     COALESCE(mv.record_count, 0) as record_count
-                FROM mv_daily_ohlc_summary mv
+                FROM mv_hourly_ohlc_summary mv
                 JOIN dim_symbol ds ON mv.symbol_code = ds.symbol_code;
             """)
             logger.info("View 'ohlc_1hour_aggregate' created.")

--- a/src/test/kotlin/sg/com/quantai/etl/controllers/ForexControllerTest.kt
+++ b/src/test/kotlin/sg/com/quantai/etl/controllers/ForexControllerTest.kt
@@ -144,6 +144,7 @@ class ForexControllerTest {
         assertEquals("success", body["status"])
         assertEquals(0, body["count"])
     }
+    @Test
     fun `should fetch and store historical forex data by date successfully`() {
         // Arrange
         `when`(forexService.getSupportedIntervals())

--- a/src/test/kotlin/sg/com/quantai/etl/controllers/StockControllerTest.kt
+++ b/src/test/kotlin/sg/com/quantai/etl/controllers/StockControllerTest.kt
@@ -115,7 +115,7 @@ class StockControllerTest {
         // Assert
         assertEquals(HttpStatus.OK, response.statusCode)
         assertEquals(
-            "Historical data for AAPL (interval=1day) from 2025-10-01 to 2025-10-31 successfully stored!",
+            "Historical data for AAPL from 2025-10-01 to 2025-10-31 successfully stored!",
             response.body
         )
     }


### PR DESCRIPTION
I accidentally deleted quantntu-76 but the changes are under (1)

1 | DataWarehouseInitializer.kt L432–456 
ohlc_1hour_aggregate view is built from mv_daily_ohlc_summary with a daily grain — copy-paste from the daily view. Any consumer expecting hourly data gets wrong data.

2 | ForexControllerTest.kt L147 
A test is missing @Test — JUnit never runs it. It's effectively dead.

3 | StockControllerTest.kt L117–118 
Assertion expects (interval=1day) in response message but the controller doesn't include that — test would fail if executed.

