### PR TITLE
perf: eliminate N+1 SQL, shared ObjectMapper, configurable rate limit…

### DIFF
--- a/src/main/kotlin/sg/com/quantai/etl/services/CryptoService.kt
+++ b/src/main/kotlin/sg/com/quantai/etl/services/CryptoService.kt
@@ -58,14 +58,7 @@ class CryptoService(
             try {
                 val historicalData = fetchHistoricalData(symbol, "USD", 10)
                 if (historicalData != null && historicalData.isArray) {
-                    historicalData.forEach { node ->
-                        val timestamp = Timestamp.from(Instant.ofEpochSecond(node["time"].asLong()))
-                        if (!checkIfDataExists(symbol, timestamp)) {
-                            insertHistoricalData(node, symbol, "USD")
-                        } else {
-                            logger.info("Data for $symbol at $timestamp already exists. Skipping storage.")
-                        }
-                    }
+                    historicalData.forEach { node -> insertHistoricalData(node, symbol, "USD") }
                 }
             } catch (e: Exception) {
                 logger.error("Error storing historical data for $symbol: ${e.message}")
@@ -80,14 +73,7 @@ class CryptoService(
             return
         }
 
-        historicalData.forEach { node ->
-            val timestamp = Timestamp.from(Instant.ofEpochSecond(node["time"].asLong()))
-            if (!checkIfDataExists(symbol, timestamp)) {
-                insertHistoricalData(node, symbol, currency)
-            } else {
-                logger.info("Data for $symbol at $timestamp already exists. Skipping storage.")
-            }
-        }
+        historicalData.forEach { node -> insertHistoricalData(node, symbol, currency) }
     }
 
     fun fetchHistoricalData(symbol: String, currency: String, limit: Int): JsonNode? {
@@ -150,14 +136,7 @@ class CryptoService(
                 return
             }
 
-            dataArray.forEach { node ->
-                val timestamp = Timestamp.from(Instant.ofEpochSecond(node["time"].asLong()))
-                if (!checkIfDataExists(symbol, timestamp)) {
-                    insertHistoricalData(node, symbol, currency)
-                } else {
-                    logger.info("Data for $symbol at $timestamp already exists. Skipping.")
-                }
-            }
+            dataArray.forEach { node -> insertHistoricalData(node, symbol, currency) }
 
             logger.info("✅ Successfully stored historical data for $symbol from $startDate to $endDate")
 
@@ -195,6 +174,7 @@ class CryptoService(
             val sql = """
                 INSERT INTO raw_crypto_compare_crypto_data (symbol, currency, open, high, low, close, volume_from, volume_to, timestamp)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (symbol, timestamp) DO NOTHING
             """
             jdbcTemplate.update(sql, symbol, currency, open, high, low, close, volumeFrom, volumeTo, timestamp)
         } catch (e: Exception) {
@@ -235,14 +215,6 @@ class CryptoService(
     }
 
 
-
-    private fun checkIfDataExists(symbol: String, timestamp: Timestamp): Boolean {
-        val sql = """
-            SELECT COUNT(*) FROM raw_crypto_compare_crypto_data WHERE symbol = ? AND timestamp = ?
-        """
-        val count = jdbcTemplate.queryForObject(sql, Int::class.java, symbol, timestamp)
-        return count != null && count > 0
-    }
 
     /**
      * Fetch historical price data for chart display (without storing).

--- a/src/main/kotlin/sg/com/quantai/etl/services/DataWarehouseETLService.kt
+++ b/src/main/kotlin/sg/com/quantai/etl/services/DataWarehouseETLService.kt
@@ -195,7 +195,7 @@ class DataWarehouseETLService(
         ) ?: 0L
         
         // Load only recent data
-        jdbcTemplate.execute("""
+        jdbcTemplate.update("""
             INSERT INTO dim_symbol (symbol_code, asset_type_id, symbol_name, is_active)
             SELECT DISTINCT 
                 ts.symbol,
@@ -203,11 +203,11 @@ class DataWarehouseETLService(
                 ts.symbol,
                 true
             FROM transformed_stock_data ts
-            WHERE ts.timestamp > NOW() - INTERVAL '$hoursBack hours'
+            WHERE ts.timestamp > NOW() - INTERVAL '1 hour' * ?
             ON CONFLICT (symbol_code, asset_type_id) DO NOTHING;
-        """)
+        """, hoursBack)
         
-        jdbcTemplate.execute("""
+        jdbcTemplate.update("""
             INSERT INTO fact_ohlc_data (
                 symbol_id, asset_type_id, interval_id, timestamp,
                 open, high, low, close, volume, price_change, source_table
@@ -228,9 +228,9 @@ class DataWarehouseETLService(
             JOIN dim_symbol ds ON ts.symbol = ds.symbol_code 
                 AND ds.asset_type_id = (SELECT asset_type_id FROM dim_asset_type WHERE asset_type_code = 'STOCK')
             JOIN dim_time_interval dti ON ts.interval = dti.interval_code
-            WHERE ts.timestamp > NOW() - INTERVAL '$hoursBack hours'
+            WHERE ts.timestamp > NOW() - INTERVAL '1 hour' * ?
             ON CONFLICT DO NOTHING;
-        """)
+        """, hoursBack)
         
         val countAfter = jdbcTemplate.queryForObject(
             "SELECT COUNT(*) FROM fact_ohlc_data WHERE asset_type_id = (SELECT asset_type_id FROM dim_asset_type WHERE asset_type_code = 'STOCK')",
@@ -304,7 +304,7 @@ class DataWarehouseETLService(
             Long::class.java
         ) ?: 0L
         
-        jdbcTemplate.execute("""
+        jdbcTemplate.update("""
             INSERT INTO dim_symbol (symbol_code, asset_type_id, symbol_name, is_active)
             SELECT DISTINCT 
                 tf.currency_pair,
@@ -312,11 +312,11 @@ class DataWarehouseETLService(
                 tf.currency_pair,
                 true
             FROM transformed_forex_data tf
-            WHERE tf.timestamp > NOW() - INTERVAL '$hoursBack hours'
+            WHERE tf.timestamp > NOW() - INTERVAL '1 hour' * ?
             ON CONFLICT (symbol_code, asset_type_id) DO NOTHING;
-        """)
+        """, hoursBack)
         
-        jdbcTemplate.execute("""
+        jdbcTemplate.update("""
             INSERT INTO fact_ohlc_data (
                 symbol_id, asset_type_id, interval_id, timestamp,
                 open, high, low, close, price_change, source_table
@@ -336,9 +336,9 @@ class DataWarehouseETLService(
             JOIN dim_symbol ds ON tf.currency_pair = ds.symbol_code 
                 AND ds.asset_type_id = (SELECT asset_type_id FROM dim_asset_type WHERE asset_type_code = 'FOREX')
             JOIN dim_time_interval dti ON tf.interval = dti.interval_code
-            WHERE tf.timestamp > NOW() - INTERVAL '$hoursBack hours'
+            WHERE tf.timestamp > NOW() - INTERVAL '1 hour' * ?
             ON CONFLICT DO NOTHING;
-        """)
+        """, hoursBack)
         
         val countAfter = jdbcTemplate.queryForObject(
             "SELECT COUNT(*) FROM fact_ohlc_data WHERE asset_type_id = (SELECT asset_type_id FROM dim_asset_type WHERE asset_type_code = 'FOREX')",
@@ -417,7 +417,7 @@ class DataWarehouseETLService(
             Long::class.java
         ) ?: 0L
         
-        jdbcTemplate.execute("""
+        jdbcTemplate.update("""
             INSERT INTO dim_symbol (symbol_code, asset_type_id, symbol_name, currency, is_active)
             SELECT DISTINCT 
                 tc.symbol,
@@ -426,11 +426,11 @@ class DataWarehouseETLService(
                 tc.currency,
                 true
             FROM transformed_crypto_data tc
-            WHERE tc.timestamp > NOW() - INTERVAL '$hoursBack hours'
+            WHERE tc.timestamp > NOW() - INTERVAL '1 hour' * ?
             ON CONFLICT (symbol_code, asset_type_id) DO NOTHING;
-        """)
+        """, hoursBack)
         
-        jdbcTemplate.execute("""
+        jdbcTemplate.update("""
             INSERT INTO fact_ohlc_data (
                 symbol_id, asset_type_id, interval_id, timestamp,
                 open, high, low, close, volume_from, volume_to, 
@@ -453,9 +453,9 @@ class DataWarehouseETLService(
             FROM transformed_crypto_data tc
             JOIN dim_symbol ds ON tc.symbol = ds.symbol_code 
                 AND ds.asset_type_id = (SELECT asset_type_id FROM dim_asset_type WHERE asset_type_code = 'CRYPTO')
-            WHERE tc.timestamp > NOW() - INTERVAL '$hoursBack hours'
+            WHERE tc.timestamp > NOW() - INTERVAL '1 hour' * ?
             ON CONFLICT DO NOTHING;
-        """)
+        """, hoursBack)
         
         val countAfter = jdbcTemplate.queryForObject(
             "SELECT COUNT(*) FROM fact_ohlc_data WHERE asset_type_id = (SELECT asset_type_id FROM dim_asset_type WHERE asset_type_code = 'CRYPTO')",

--- a/src/main/kotlin/sg/com/quantai/etl/services/NewsArticleBBCService.kt
+++ b/src/main/kotlin/sg/com/quantai/etl/services/NewsArticleBBCService.kt
@@ -20,7 +20,8 @@ import reactor.util.retry.Retry
 
 @Service
 class NewsArticleBBCService(
-    @Autowired private val newsArticlesBBCRepository: NewsArticleBBCRepository
+    @Autowired private val newsArticlesBBCRepository: NewsArticleBBCRepository,
+    private val objectMapper: ObjectMapper
 ) {
 
     @Value("\${quantai.external.api.newsarticle.bbc}")
@@ -100,7 +101,6 @@ class NewsArticleBBCService(
     }
 
     private fun parseResponse(response: String): JsonNode {
-        val objectMapper = ObjectMapper()
         return objectMapper.readTree(response)
     }
 

--- a/src/main/kotlin/sg/com/quantai/etl/services/StockService.kt
+++ b/src/main/kotlin/sg/com/quantai/etl/services/StockService.kt
@@ -33,6 +33,7 @@ class StockService(
     private val webClientBuilder: WebClient.Builder,
     @Value("\${quantai.external.api.twelvedata.url}") private val twelveDataBaseUrl: String,
     @Value("\${quantai.external.api.twelvedata.key}") private val apiKey: String,
+    @Value("\${quantai.etl.stock.rate-limit-ms:1000}") private val rateLimitMs: Long,
     private val objectMapper: ObjectMapper,
     private val jdbcTemplate: JdbcTemplate,
     private val twelveDataApiClient: TwelveDataApiClient
@@ -58,7 +59,7 @@ class StockService(
             try {
                 logger.info("Fetching 14-year history for $symbol ($startDate to $endDate)")
                 fetchAndStoreHistoricalDataByDate(symbol, "1day", startDate, endDate)
-                Thread.sleep(1000)
+                Thread.sleep(rateLimitMs)
             } catch (e: Exception) {
                 logger.error("Error storing historical data for $symbol: ${e.message}")
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,3 +28,5 @@ quantai.external.api.cryptocompare.url=https://min-api.cryptocompare.com
 ## Twelve Data API for stocks and forex
 quantai.external.api.twelvedata.key=${TWELVEDATA_API_KEY:your_api_key_here}
 quantai.external.api.twelvedata.url=https://api.twelvedata.com
+## Rate limit delay between symbol fetches (ms) to respect Twelve Data API limits
+quantai.etl.stock.rate-limit-ms=1000


### PR DESCRIPTION

- CryptoService: replace per-row checkIfDataExists() COUNT queries with ON CONFLICT DO NOTHING upsert
- NewsArticleBBCService: inject shared ObjectMapper bean instead of allocating new ObjectMapper() per parseResponse() call
- StockService: replace hardcoded Thread.sleep(1000) with configurable quantai.etl.stock.rate-limit-ms property (default 1000ms)
- DataWarehouseETLService: replace string-interpolated INTERVAL '$hoursBack hours' with parameterized INTERVAL '1 hour' * ? across all 3 incremental load functions (stock, forex, crypto)
